### PR TITLE
Add modal to accepted components in CommandGroup & SlashCommand

### DIFF
--- a/packages/core/src/app/commands/CommandGroup.ts
+++ b/packages/core/src/app/commands/CommandGroup.ts
@@ -24,7 +24,7 @@ export class CommandGroup implements ICommandGroup {
   public builder: CommandGroupBuilder;
   public handlers: ISubcommandHandlers;
 
-  constructor(builder: CommandGroupBuilder, handlers: ISubcommandHandlers, components: Component[] = []) {
+  constructor(builder: CommandGroupBuilder, handlers: ISubcommandHandlers, components: (Component | Modal)[] = []) {
     this.builder = builder;
     this.handlers = handlers;
 

--- a/packages/core/src/app/commands/SlashCommand.ts
+++ b/packages/core/src/app/commands/SlashCommand.ts
@@ -19,7 +19,7 @@ export class SlashCommand
     handler: (ctx: SlashCommandContext) => Promise<void> = async (ctx: SlashCommandContext) => {
       ctx.reply("No command handler has been defined.");
     },
-    components: Component[] = [],
+    components: (Component | Modal)[] = [],
     autocompleteHandler: (ctx: AutocompleteContext) => Promise<void> = async (ctx: AutocompleteContext) => {
       ctx.reply([]);
     }


### PR DESCRIPTION
This adds support for Modal class to be used as a component within a SlashCommand & CommandGroup constructor.