### PR TITLE
Fix failure where launch type command is found and can't sync.

### DIFF
--- a/packages/core/src/app/managers/CommandManager.ts
+++ b/packages/core/src/app/managers/CommandManager.ts
@@ -78,8 +78,7 @@ export class CommandManager {
     const parsed = {
       [ApplicationCommandType.ChatInput]: new Map(),
       [ApplicationCommandType.User]: new Map(),
-      [ApplicationCommandType.Message]: new Map(),
-      [ApplicationCommandType.Launch]: new Map()
+      [ApplicationCommandType.Message]: new Map()
     };
 
     commands.map((command) => parsed[command.type]?.set(command.name, command));

--- a/packages/core/src/app/managers/CommandManager.ts
+++ b/packages/core/src/app/managers/CommandManager.ts
@@ -78,10 +78,11 @@ export class CommandManager {
     const parsed = {
       [ApplicationCommandType.ChatInput]: new Map(),
       [ApplicationCommandType.User]: new Map(),
-      [ApplicationCommandType.Message]: new Map()
+      [ApplicationCommandType.Message]: new Map(),
+      [ApplicationCommandType.Launch]: new Map()
     };
 
-    commands.map((command) => parsed[command.type].set(command.name, command));
+    commands.map((command) => parsed[command.type]?.set(command.name, command));
 
     return parsed;
   }
@@ -101,11 +102,11 @@ export class CommandManager {
    * @param type Command type
    */
   get(name: string, type: ApplicationCommandType = ApplicationCommandType.ChatInput): RegisteredCommand | undefined {
-    return this[type].get(name);
+    return this[type]?.get(name);
   }
 
   set(name: string, type: ApplicationCommandType = ApplicationCommandType.ChatInput, command: RegisteredCommand): void {
-    this[type].set(name, command as never);
+    this[type]?.set(name, command as never);
   }
 
   /**

--- a/packages/core/src/app/managers/CommandManager.ts
+++ b/packages/core/src/app/managers/CommandManager.ts
@@ -81,7 +81,14 @@ export class CommandManager {
       [ApplicationCommandType.Message]: new Map()
     };
 
-    commands.map((command) => parsed[command.type]?.set(command.name, command));
+    commands.map((command) => {
+      if (parsed?.[command.type] === undefined) {
+        console.warn(`Unrecognized command type: ${command.type}`);
+        return;
+      }
+
+      parsed[command.type].set(command.name, command);
+    });
 
     return parsed;
   }
@@ -101,11 +108,11 @@ export class CommandManager {
    * @param type Command type
    */
   get(name: string, type: ApplicationCommandType = ApplicationCommandType.ChatInput): RegisteredCommand | undefined {
-    return this[type]?.get(name);
+    return this[type].get(name);
   }
 
   set(name: string, type: ApplicationCommandType = ApplicationCommandType.ChatInput, command: RegisteredCommand): void {
-    this[type]?.set(name, command as never);
+    this[type].set(name, command as never);
   }
 
   /**


### PR DESCRIPTION
When we try to sync existing commands, it will iterate through the ones returned and already recognised by this discord app, and may return command such as `launch` - which has a type/index of 4.  This goes out of range, so crashes the parse command when it tries to set this within a map that doesn't exist.

For now the simple solution will be to just put a null check on that array index in case you get any unknown command types come back - eg, new features that have come along since this library was written, as is the case here.

But It would also be a good idea to not only have these checks, but update the library to use the latest ApplicationCommandType definitions that include these new unrecognised types.